### PR TITLE
fix vs2015 build

### DIFF
--- a/Scylla/DisassemblerGui.cpp
+++ b/Scylla/DisassemblerGui.cpp
@@ -353,29 +353,29 @@ bool DisassemblerGui::getDisassemblyComment(unsigned int index)
 				#ifdef _WIN64
 				addressTemp = (DWORD_PTR)INSTRUCTION_GET_RIP_TARGET(&ProcessAccessHelp::decomposerResult[index]);
 
-				swprintf_s(tempBuffer,L"-> "PRINTF_DWORD_PTR_FULL,addressTemp);
+				swprintf_s(tempBuffer,L"-> " PRINTF_DWORD_PTR_FULL,addressTemp);
 
 				if(ProcessAccessHelp::readMemoryFromProcess(addressTemp, sizeof(DWORD_PTR), &address))
 				{
-					swprintf_s(tempBuffer,L"%s -> "PRINTF_DWORD_PTR_FULL,tempBuffer,address);
+					swprintf_s(tempBuffer,L"%s -> " PRINTF_DWORD_PTR_FULL,tempBuffer,address);
 				}
 				#endif
 			}
 			else if (ProcessAccessHelp::decomposerResult[index].ops[0].type == O_PC)
 			{
 				address = (DWORD_PTR)INSTRUCTION_GET_TARGET(&ProcessAccessHelp::decomposerResult[index]);
-				swprintf_s(tempBuffer,L"-> "PRINTF_DWORD_PTR_FULL,address);
+				swprintf_s(tempBuffer,L"-> " PRINTF_DWORD_PTR_FULL,address);
 			}
 			else if (ProcessAccessHelp::decomposerResult[index].ops[0].type == O_DISP)
 			{
 				addressTemp = (DWORD_PTR)ProcessAccessHelp::decomposerResult[index].disp;
 
-				swprintf_s(tempBuffer,L"-> "PRINTF_DWORD_PTR_FULL,addressTemp);
+				swprintf_s(tempBuffer,L"-> " PRINTF_DWORD_PTR_FULL,addressTemp);
 
 				address = 0;
 				if(ProcessAccessHelp::readMemoryFromProcess(addressTemp, sizeof(DWORD_PTR), &address))
 				{
-					swprintf_s(tempBuffer,L"%s -> "PRINTF_DWORD_PTR_FULL,tempBuffer,address);
+					swprintf_s(tempBuffer,L"%s -> " PRINTF_DWORD_PTR_FULL,tempBuffer,address);
 				}
 			}
 		}

--- a/Scylla/TreeImportExport.cpp
+++ b/Scylla/TreeImportExport.cpp
@@ -42,7 +42,7 @@ bool TreeImportExport::importTreeList(std::map<DWORD_PTR, ImportModuleThunk> & m
 	TiXmlElement * targetElement = doc.FirstChildElement();
 	if (!targetElement)
 	{
-		Sylla::windowLog.log(L"Load Tree :: Error getting first child element in xml %S\r\n", doc.Value());
+		Scylla::windowLog.log(L"Load Tree :: Error getting first child element in xml %S\r\n", doc.Value());
 		return false;
 	}
 


### PR DESCRIPTION
- Fix error C3688 mentionned in this issue : https://github.com/NtQuery/Scylla/issues/37.
- Fix error C2653

In VS 2015, there is also an assert: 

> <hash_map> is deprecated and will be REMOVED. ; Please use <unordered_map>

A temporary fix should be to add the preprocessor definitions : "_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS".
