### PR TITLE
Fix error c2688 when compiling with VS2015

### DIFF
--- a/Scylla/DisassemblerGui.cpp
+++ b/Scylla/DisassemblerGui.cpp
@@ -353,29 +353,29 @@ bool DisassemblerGui::getDisassemblyComment(unsigned int index)
 				#ifdef _WIN64
 				addressTemp = (DWORD_PTR)INSTRUCTION_GET_RIP_TARGET(&ProcessAccessHelp::decomposerResult[index]);
 
-				swprintf_s(tempBuffer,L"-> "PRINTF_DWORD_PTR_FULL,addressTemp);
+				swprintf_s(tempBuffer,L"-> " PRINTF_DWORD_PTR_FULL,addressTemp);
 
 				if(ProcessAccessHelp::readMemoryFromProcess(addressTemp, sizeof(DWORD_PTR), &address))
 				{
-					swprintf_s(tempBuffer,L"%s -> "PRINTF_DWORD_PTR_FULL,tempBuffer,address);
+					swprintf_s(tempBuffer,L"%s -> " PRINTF_DWORD_PTR_FULL,tempBuffer,address);
 				}
 				#endif
 			}
 			else if (ProcessAccessHelp::decomposerResult[index].ops[0].type == O_PC)
 			{
 				address = (DWORD_PTR)INSTRUCTION_GET_TARGET(&ProcessAccessHelp::decomposerResult[index]);
-				swprintf_s(tempBuffer,L"-> "PRINTF_DWORD_PTR_FULL,address);
+				swprintf_s(tempBuffer,L"-> " PRINTF_DWORD_PTR_FULL,address);
 			}
 			else if (ProcessAccessHelp::decomposerResult[index].ops[0].type == O_DISP)
 			{
 				addressTemp = (DWORD_PTR)ProcessAccessHelp::decomposerResult[index].disp;
 
-				swprintf_s(tempBuffer,L"-> "PRINTF_DWORD_PTR_FULL,addressTemp);
+				swprintf_s(tempBuffer,L"-> " PRINTF_DWORD_PTR_FULL,addressTemp);
 
 				address = 0;
 				if(ProcessAccessHelp::readMemoryFromProcess(addressTemp, sizeof(DWORD_PTR), &address))
 				{
-					swprintf_s(tempBuffer,L"%s -> "PRINTF_DWORD_PTR_FULL,tempBuffer,address);
+					swprintf_s(tempBuffer,L"%s -> " PRINTF_DWORD_PTR_FULL,tempBuffer,address);
 				}
 			}
 		}


### PR DESCRIPTION
Since C++11, there is such a thing as user-defined literals, which means
it's not possible anymore to append a macro defined literal since it will be
treated as a preprocessing token. A simple fix is to leave a whitespace in
order to specify the two literals are separate tokens.

More info :
	* http://stackoverflow.com/questions/31738796/using-macro-with-string-fails-on-vc-2015
	* http://en.cppreference.com/w/cpp/language/user_literal
