### PR TITLE
Fix typo in namespace Sylla -> Scylla

### DIFF
--- a/Scylla/TreeImportExport.cpp
+++ b/Scylla/TreeImportExport.cpp
@@ -42,7 +42,7 @@ bool TreeImportExport::importTreeList(std::map<DWORD_PTR, ImportModuleThunk> & m
 	TiXmlElement * targetElement = doc.FirstChildElement();
 	if (!targetElement)
 	{
-		Sylla::windowLog.log(L"Load Tree :: Error getting first child element in xml %S\r\n", doc.Value());
+		Scylla::windowLog.log(L"Load Tree :: Error getting first child element in xml %S\r\n", doc.Value());
 		return false;
 	}
 


### PR DESCRIPTION
It might be a good idea to use a Continuous Integration system such as coverage in order to catch these silly mistakes.